### PR TITLE
fix: license owner name: kanarus → t3tra-dev

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-present kanarus
+Copyright (c) 2024-present t3tra-dev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -163,4 +163,4 @@ thanks for all contributors!
 
 ---
 
-`pyinit` is licensed under the MIT License. See the [LICENSE](https://github.com/kanarus/pyinit/blob/main/LICENSE) file for more details.
+`pyinit` is licensed under the MIT License. See the [LICENSE](https://github.com/t3tra-dev/pyinit/blob/main/LICENSE) file for more details.


### PR DESCRIPTION
When I forked the project, I changed the license owner to my name because I didn’t plan to merge my refactoring into the upstream. However, it ended up getting merged, so I’m submitting this PR to correct the license owner.